### PR TITLE
bugfix: tentative fix for two out of bounds bugs in pdmk driver

### DIFF
--- a/src/pdmk/pdmk.f
+++ b/src/pdmk/pdmk.f
@@ -436,13 +436,9 @@ c     leaf boxes
 
       if (nboxsrcpts(1).le.ndiv) ifleafbox(1)=1
       
-      do ilev=0,nlevels
+      do ilev=1,nlevels
          do ibox=itree(2*ilev+1),itree(2*ilev+2)
             dad =  itree(iptr(3)+ibox-1)
-c           dad = -1 -> out of bounds access in nboxsrcpts
-            if (dad.lt.1) then
-               dad = 1
-            endif
             if (nboxsrcpts(ibox) .le. ndiv .and.
      1          nboxsrcpts(dad).gt.ndiv .and.
      2          nboxsrcpts(ibox) .gt. 0) then


### PR DESCRIPTION
@sj90101 
I have found a couple of bounds bugs in the pdmk driver. `nboxsrcpoints` overflows because `dad` can be `-1`. I assume the right thing to do here is treat it as the root, but I'm not sure. I'm not familiar with the tree code at all.

`rl` was having bounds issues because the `yukawa_local_kernel_coefs` loop at line 689 steps to `nlevels`, while `rl` is allocated from `-1:nlevels-1`. Do these fixes look correct?