### PR TITLE
add compile flags in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,41 @@ cmake .. -DCMAKE_BUILD_TYPE=relwithdebinfo -DBLA_VENDOR=FlexiBLAS
 make -j 10
 ```
 
+## C++ Build — canonical (reproducible)
+
+These are the exact flags used for benchmark numbers. clang 19 with an
+AVX-512 target produces clean, host-portable perf across Flatiron's Zen 4,
+Cascade Lake, and Ice Lake hosts.
+
+```bash
+# Flatiron module stack
+module -q reset
+module load modules/2.4
+module use ~/modules
+module -q load python gcc/14 cmake openmpi openblas/single flexiblas \
+               llvm/19 doxygen papi perf-linux ninja
+
+mkdir -p build-x86v4-rwd && cd build-x86v4-rwd
+C_INCLUDE_PATH= CPLUS_INCLUDE_PATH= cmake .. \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
+  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_CXX_FLAGS="-march=x86-64-v4 -fno-omit-frame-pointer" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBLA_VENDOR=OpenBLAS -G Ninja
+cmake --build . -j
+```
+
+Flag rationale:
+
+| Flag | Purpose |
+|------|---------|
+| `-march=x86-64-v4` | Portable AVX-512 target. Deterministic across Zen 4 / Cascade Lake / Ice Lake vs `-march=native`. |
+| `-fno-omit-frame-pointer` | Keeps frame pointers for profilers (perf, vtune). |
+| `RelWithDebInfo` | Full optimization + debug symbols. |
+| `-G Ninja` | Faster parallel builds. |
+| `BLA_VENDOR=OpenBLAS` | Single-threaded OpenBLAS (from `openblas/single` module). |
+| Empty `C_INCLUDE_PATH` / `CPLUS_INCLUDE_PATH` | Prevents stray system paths polluting header search. |
+
 # Building on mac
 Currently an OpenMP capable compiler is required to build the code, which the MacOS default
 clang is not. I have managed to get the build working with clang++ from brew via the following.

--- a/examples/compare_dmk_pvfmm.cpp
+++ b/examples/compare_dmk_pvfmm.cpp
@@ -25,6 +25,7 @@ struct Config {
     bool uniform = false;
     bool enable_pvfmm = true;
     bool enable_direct = true;
+    bool pbc = false;
     int n_direct = -1; // -1 means "same as n_src"
     int n_runs = 100;
     int log_level = DMK_LOG_OFF; // 6: off, 5: critical, 4: err, 3: warn, 2: info, 1: debug, 0: trace
@@ -83,7 +84,8 @@ void print_csv_config_comment(const Config &cfg, int np, int n_threads, std::ost
        << "# m_pvfmm:              " << cfg.m_pvfmm << "\n"
        << "# direct_enabled:       " << cfg.enable_direct << "\n"
        << "# n_direct:             " << cfg.n_direct << "\n"
-       << "# log_level:            " << cfg.log_level << "\n";
+       << "# log_level:            " << cfg.log_level << "\n"
+       << "# pbc:                  " << cfg.pbc << "\n";
 }
 
 void print_csv_header(std::ostream &os) {
@@ -302,6 +304,7 @@ void run_comparison(const Config &cfg) {
     params.pgh_src = DMK_POTENTIAL;
     params.pgh_trg = DMK_POTENTIAL;
     params.kernel = DMK_LAPLACE;
+    params.use_periodic = cfg.pbc ? 1 : 0;
 
     std::vector<Real> r_trg; // self-evaluation: empty target list
     pdmk_tree dmk_tree;
@@ -413,6 +416,7 @@ Config parse_args(int argc, char *argv[]) {
         {"no-pvfmm", no_argument, nullptr, 1002},
         {"direct",   no_argument, nullptr, 1003},
         {"no-direct",no_argument, nullptr, 1004},
+        {"pbc",      no_argument, nullptr, 1005},
         {nullptr, 0, nullptr, 0}
     };
 
@@ -437,6 +441,7 @@ Config parse_args(int argc, char *argv[]) {
         case 1002:   cfg.enable_pvfmm  = false; break;
         case 1003:   cfg.enable_direct = true;  break;
         case 1004:   cfg.enable_direct = false; break;
+        case 1005:   cfg.pbc           = true;  break;
         case 'h':
         case '?':
         default:
@@ -454,6 +459,7 @@ Config parse_args(int argc, char *argv[]) {
                 << "  -u                     Uniform random distribution\n"
                 << "  --pvfmm / --no-pvfmm   Enable/disable PVFMM comparison\n"
                 << "  --direct / --no-direct Enable/disable all-pairs reference\n"
+                << "  --pbc                  Enable periodic boundary conditions (default: free-space)\n"
                 << "  -h                     This help message\n";
             std::exit(0);
         }


### PR DESCRIPTION
Described the compile flags for best performance.
Added a `--pbc` flag for the `examples/compare_dmk_pvfmm.cpp`.