### PR TITLE
fix(tree): avoid int32 overflow sizing pw_out at large N

### DIFF
--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -948,7 +948,7 @@ void DMKPtTree<Real, DIM>::init_planewave_data() {
             } else
                 pw_out_offsets[box] = -1;
         }
-        pw_out.ReInit(n_pw_per_box * n_pw_boxes_out);
+        pw_out.ReInit(last_offset);
     }
 }
 


### PR DESCRIPTION
n_pw_per_box * n_pw_boxes_out was computed in int before being widened to Long for Vector::ReInit. For sphere N=1e7 at d>=9 the product exceeds 2^31 and wraps, producing a too-small pw_out buffer; subsequent PW GEMMs write past the end and segfault in the OpenBLAS c/zgemm beta micro-kernel. Use the loop's int64 running total (last_offset) as the allocation size.