### PR TITLE
fix(tree): initialize w0[n_levels()] extra slot in evaluate_direct_in…

### DIFF
--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -1155,6 +1155,15 @@ void DMKPtTree<Real, DIM>::evaluate_direct_interactions() {
     Real w0[SCTL_MAX_DEPTH];
     for (int i_level = 0; i_level < n_levels(); ++i_level)
         w0[i_level] = get_self_interaction_constant<Real, DIM>(fourier_data, params.kernel, i_level, boxsize[i_level]);
+    // Leaves with ifpwexp=1 use depth = box_depth + 1, which can reach
+    // n_levels() when a max-depth leaf has ifpwexp=1 (see the depth
+    // computation near the self-correction step). Initialize that extra
+    // slot with the self-interaction constant at boxsize/2 of the deepest
+    // level; otherwise w0[n_levels()] is read uninitialized.
+    if (n_levels() > 0 && n_levels() < SCTL_MAX_DEPTH) {
+        const Real bs_extra = boxsize[n_levels() - 1] / Real(2);
+        w0[n_levels()] = get_self_interaction_constant<Real, DIM>(fourier_data, params.kernel, n_levels(), bs_extra);
+    }
 
     // For PBC: precompute the periodic shift for each (trg_box, nbr_index) pair.
     // The nbr array index k encodes a direction (dx,dy,dz) ∈ {-1,0,+1}^DIM.

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -1153,17 +1153,9 @@ void DMKPtTree<Real, DIM>::evaluate_direct_interactions() {
     const auto &node_lists = this->GetNodeLists();
 
     Real w0[SCTL_MAX_DEPTH];
-    for (int i_level = 0; i_level < n_levels(); ++i_level)
+    // Fill for n_levels+1, note boxsize is already n_levels+1 in size
+    for (int i_level = 0; i_level < std::min(SCTL_MAX_DEPTH, n_levels() + 1); ++i_level)
         w0[i_level] = get_self_interaction_constant<Real, DIM>(fourier_data, params.kernel, i_level, boxsize[i_level]);
-    // Leaves with ifpwexp=1 use depth = box_depth + 1, which can reach
-    // n_levels() when a max-depth leaf has ifpwexp=1 (see the depth
-    // computation near the self-correction step). Initialize that extra
-    // slot with the self-interaction constant at boxsize/2 of the deepest
-    // level; otherwise w0[n_levels()] is read uninitialized.
-    if (n_levels() > 0 && n_levels() < SCTL_MAX_DEPTH) {
-        const Real bs_extra = boxsize[n_levels() - 1] / Real(2);
-        w0[n_levels()] = get_self_interaction_constant<Real, DIM>(fourier_data, params.kernel, n_levels(), bs_extra);
-    }
 
     // For PBC: precompute the periodic shift for each (trg_box, nbr_index) pair.
     // The nbr array index k encodes a direction (dx,dy,dz) ∈ {-1,0,+1}^DIM.


### PR DESCRIPTION
…teractions

`evaluate_direct_interactions` computes the self-correction factor as

    const auto depth = node_mid[trg_box].Depth() + ifpwexp[trg_box];
    const auto correction_factor = w0[depth];

For a leaf at max depth with `ifpwexp=1`, `depth = n_levels()`, but the initialization loop only fills `w0[0..n_levels()-1]`. The `w0[n_levels()]` read returns stack garbage and perturbs the self-correction by a data-dependent, non-repeatable amount.

Fix: initialize the extra slot with the self-interaction constant at `boxsize[n_levels()-1] / 2` (one effective level below the deepest real level), matching what the `depth = n_levels()` index semantically wants.