### PR TITLE
fix(tree): cap src_level in evaluate_direct_interactions, restore bsi…

### DIFF
--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -1194,13 +1194,20 @@ void DMKPtTree<Real, DIM>::evaluate_direct_interactions() {
                 int src_level = node_mid[src_box].Depth();
                 Real bsize = boxsize[src_level];
 
-                if (ifpwexp[src_box] && src_box == trg_box && src_level + 1 < n_levels()) {
+                if (ifpwexp[src_box] && src_box == trg_box) {
                     bsize /= Real{2.0};
                     src_level = src_level + 1;
                 } else if (src_level < trg_level) {
                     bsize = boxsize[trg_level];
                     src_level = trg_level;
                 }
+                // evaluator_by_level_src is sized n_levels() for Laplace;
+                // the self-pair branch above bumps src_level to n_levels(),
+                // which is OOB. Cap the index (all entries for Laplace are
+                // the same evaluator). For Yukawa the vector is extended to
+                // 2*n_levels() so the cap is a no-op.
+                if (src_level >= (int)evaluator_by_level_src.size())
+                    src_level = (int)evaluator_by_level_src.size() - 1;
 
                 const Real d2max = bsize * bsize;
                 const Real bsizeinv = Real{1} / bsize;

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -1201,13 +1201,9 @@ void DMKPtTree<Real, DIM>::evaluate_direct_interactions() {
                     bsize = boxsize[trg_level];
                     src_level = trg_level;
                 }
-                // evaluator_by_level_src is sized n_levels() for Laplace;
-                // the self-pair branch above bumps src_level to n_levels(),
-                // which is OOB. Cap the index (all entries for Laplace are
-                // the same evaluator). For Yukawa the vector is extended to
-                // 2*n_levels() so the cap is a no-op.
-                if (src_level >= (int)evaluator_by_level_src.size())
-                    src_level = (int)evaluator_by_level_src.size() - 1;
+                // evaluator_by_level_src is sized n_levels()
+                // This fix is essentially for when there is *only* a root box.
+                src_level = std::min(src_level, n_levels() - 1);
 
                 const Real d2max = bsize * bsize;
                 const Real bsizeinv = Real{1} / bsize;


### PR DESCRIPTION
…ze/2 for single-box self-pair

For a self-pair at a leaf with ifpwexp=1, the correct near-field kernel range is boxsize/2 (matches Fortran pdmk_direct_c; matches DMK's own PW pass which applies the windowed kernel at boxsize/2 scale for such a leaf). The current guard

    if (ifpwexp[src_box] && src_box == trg_box && src_level + 1 < n_levels())

skips the halving whenever `src_level + 1 >= n_levels()`, which is exactly the single-box case (root is leaf, n_levels=1) and the deepest-leaf case (leaf at max_depth with ifpwexp=1, src_level+1 == n_levels()). In both, the direct kernel ends up using full boxsize while the PW pass used boxsize/2, producing an inconsistent near/far-field split.

The guard was added to avoid an OOB at `evaluator_by_level_src[src_level]` (sized n_levels() for Laplace). Fix the OOB directly by capping src_level to the last valid index instead of skipping the halving. For Laplace all evaluator entries are the same so the cap is semantically exact; for Yukawa the vector is 2*n_levels() and the cap is a no-op.

Relevant symptom before this fix: a 3-particle single-box 2D Laplace case failed with ~1.5 absolute error; 3D single-box segfaulted (UB dispatch through an out-of-bounds std::function slot).