### PR TITLE
fix(tree): eliminate OMP write race in upward_pass charge2proxycharge…

### DIFF
--- a/include/dmk/tree.hpp
+++ b/include/dmk/tree.hpp
@@ -354,6 +354,9 @@ Real get_self_interaction_constant(FourierData<Real> &fourier_data, dmk_ikernel 
 
 template <typename Real, int DIM>
 struct DMKPtTree : public sctl::PtTree<Real, DIM> {
+    static constexpr int NCHILD = sctl::pow<DIM>(2);
+    static constexpr int NCOLLEAGUE = sctl::pow<DIM>(3);
+
     sctl::Vector<sctl::Vector<int>> level_indices;
     sctl::Vector<Real> boxsize;
     sctl::Vector<Real> centers;
@@ -412,12 +415,13 @@ struct DMKPtTree : public sctl::PtTree<Real, DIM> {
     std::vector<int> direct_work;
 
     sctl::Vector<bool> has_proxy_from_children;
-    struct C2PWork {
-        int src_box;
+    struct Charge2ProxyGroup {
         int center_box;
         int level;
+        std::array<int, NCHILD> src_boxes;
+        int n_src_boxes;
     };
-    std::vector<C2PWork> charge2proxy_work;
+    std::vector<Charge2ProxyGroup> charge2proxy_groups;
 
     struct LevelFourierData {
         sctl::Vector<std::complex<Real>> poly2pw;

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -861,17 +861,36 @@ void DMKPtTree<Real, DIM>::upward_pass() {
         sctl::Profile::Scoped profile("charge2proxy", &comm_);
         sctl::Profile::Tic("charge2proxy", &comm_);
 
-        // charge2proxycharge
+        // charge2proxycharge: several work items can share the same
+        // center_box (a parent whose multiple !ifpwexp children with
+        // sources each contribute a {child_box, parent_box} work item —
+        // see build_upward_pass_work_lists). charge2proxycharge
+        // accumulates into its output, so those same-center items must be
+        // serialized to avoid a write race on proxy_view_upward(center).
+        // Group work items by center_box first, then parallelize over
+        // groups so each center is entirely handled by a single thread.
+        std::vector<std::vector<int>> c2p_groups_by_center(n_boxes());
+        for (int i = 0; i < charge2proxy_work.size(); ++i)
+            c2p_groups_by_center[charge2proxy_work[i].center_box].push_back(i);
+        std::vector<int> c2p_active_centers;
+        c2p_active_centers.reserve(n_boxes());
+        for (int b = 0; b < n_boxes(); ++b)
+            if (!c2p_groups_by_center[b].empty())
+                c2p_active_centers.push_back(b);
+
 #pragma omp parallel
         {
             sctl::Vector<Real> &workspace = workspaces_[MY_OMP_GET_THREAD_NUM()];
 
-#pragma omp for schedule(static)
-            for (int i = 0; i < charge2proxy_work.size(); ++i) {
-                const auto &w = charge2proxy_work[i];
-                proxy::charge2proxycharge<Real, DIM>(r_src_owned_view(w.src_box), charge_owned_view(w.src_box),
-                                                     center_view(w.center_box), 2.0 / boxsize[w.level],
-                                                     proxy_view_upward(w.center_box), workspace);
+#pragma omp for schedule(dynamic)
+            for (int gi = 0; gi < (int)c2p_active_centers.size(); ++gi) {
+                const int cb = c2p_active_centers[gi];
+                for (int i : c2p_groups_by_center[cb]) {
+                    const auto &w = charge2proxy_work[i];
+                    proxy::charge2proxycharge<Real, DIM>(r_src_owned_view(w.src_box), charge_owned_view(w.src_box),
+                                                         center_view(w.center_box), 2.0 / boxsize[w.level],
+                                                         proxy_view_upward(w.center_box), workspace);
+                }
             }
         }
         sctl::Profile::Toc();

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -541,12 +541,11 @@ template <typename Real, int DIM>
 void DMKPtTree<Real, DIM>::build_upward_pass_work_lists() {
     const auto &node_lists = this->GetNodeLists();
     has_proxy_from_children.ReInit(n_boxes());
-    charge2proxy_work.clear();
+    charge2proxy_groups.clear();
 
     for (int i_level = n_levels() - 1; i_level >= 0; --i_level) {
         for (auto i_box : level_indices[i_level]) {
             has_proxy_from_children[i_box] = false;
-
             if (!(src_counts_owned[i_box] > 0 && ifpwexp[i_box]))
                 continue;
 
@@ -557,14 +556,19 @@ void DMKPtTree<Real, DIM>::build_upward_pass_work_lists() {
                 }
             }
 
+            Charge2ProxyGroup g{.center_box = i_box, .level = i_level, .n_src_boxes = 0};
             if (has_proxy_from_children[i_box]) {
                 for (auto cb : node_lists[i_box].child) {
                     if (cb >= 0 && src_counts_owned[cb] > 0 && !ifpwexp[cb])
-                        charge2proxy_work.push_back({(int)cb, i_box, i_level});
+                        g.src_boxes[g.n_src_boxes++] = cb;
                 }
+                if (g.n_src_boxes == 0)
+                    continue;
             } else {
-                charge2proxy_work.push_back({i_box, i_box, i_level});
+                g.src_boxes[g.n_src_boxes++] = i_box;
             }
+
+            charge2proxy_groups.push_back(g);
         }
     }
 }
@@ -861,35 +865,19 @@ void DMKPtTree<Real, DIM>::upward_pass() {
         sctl::Profile::Scoped profile("charge2proxy", &comm_);
         sctl::Profile::Tic("charge2proxy", &comm_);
 
-        // charge2proxycharge: several work items can share the same
-        // center_box (a parent whose multiple !ifpwexp children with
-        // sources each contribute a {child_box, parent_box} work item —
-        // see build_upward_pass_work_lists). charge2proxycharge
-        // accumulates into its output, so those same-center items must be
-        // serialized to avoid a write race on proxy_view_upward(center).
-        // Group work items by center_box first, then parallelize over
-        // groups so each center is entirely handled by a single thread.
-        std::vector<std::vector<int>> c2p_groups_by_center(n_boxes());
-        for (int i = 0; i < charge2proxy_work.size(); ++i)
-            c2p_groups_by_center[charge2proxy_work[i].center_box].push_back(i);
-        std::vector<int> c2p_active_centers;
-        c2p_active_centers.reserve(n_boxes());
-        for (int b = 0; b < n_boxes(); ++b)
-            if (!c2p_groups_by_center[b].empty())
-                c2p_active_centers.push_back(b);
-
 #pragma omp parallel
         {
             sctl::Vector<Real> &workspace = workspaces_[MY_OMP_GET_THREAD_NUM()];
 
 #pragma omp for schedule(dynamic)
-            for (int gi = 0; gi < (int)c2p_active_centers.size(); ++gi) {
-                const int cb = c2p_active_centers[gi];
-                for (int i : c2p_groups_by_center[cb]) {
-                    const auto &w = charge2proxy_work[i];
-                    proxy::charge2proxycharge<Real, DIM>(r_src_owned_view(w.src_box), charge_owned_view(w.src_box),
-                                                         center_view(w.center_box), 2.0 / boxsize[w.level],
-                                                         proxy_view_upward(w.center_box), workspace);
+            for (int gi = 0; gi < (int)charge2proxy_groups.size(); ++gi) {
+                const auto &g = charge2proxy_groups[gi];
+                const Real scale = 2.0 / boxsize[g.level];
+                for (int k = 0; k < g.n_src_boxes; ++k) {
+                    const int sb = g.src_boxes[k];
+                    proxy::charge2proxycharge<Real, DIM>(r_src_owned_view(sb), charge_owned_view(sb),
+                                                         center_view(g.center_box), scale,
+                                                         proxy_view_upward(g.center_box), workspace);
                 }
             }
         }

--- a/src/tree_pq.cpp
+++ b/src/tree_pq.cpp
@@ -132,28 +132,11 @@ void DMKPtTree<T, DIM>::eval_pq() {
     // =================================================================
     // Build upward pass task dependency graph
     // =================================================================
-    // Group charge2proxy work items by center_box to avoid write races.
-    // Each group becomes one task.
-    struct C2PGroup {
-        int center_box;
-        int level;
-        std::vector<int> src_boxes;
-    };
-    std::vector<C2PGroup> c2p_groups;
-    {
-        std::vector<int> center_to_group(n_boxes(), -1);
-        for (auto &w : charge2proxy_work) {
-            if (center_to_group[w.center_box] == -1) {
-                center_to_group[w.center_box] = (int)c2p_groups.size();
-                c2p_groups.push_back({w.center_box, w.level, {w.src_box}});
-            } else {
-                c2p_groups[center_to_group[w.center_box]].src_boxes.push_back(w.src_box);
-            }
-        }
-    }
+    const auto &c2p_groups = charge2proxy_groups;
+
     // Map center_box -> index into c2p_groups (for dependency wiring)
     std::vector<int> box_to_c2p_group(n_boxes(), -1);
-    for (int g = 0; g < (int)c2p_groups.size(); ++g)
+    for (int g = 0; g < c2p_groups.size(); ++g)
         box_to_c2p_group[c2p_groups[g].center_box] = g;
     t_c2p = MY_OMP_GET_WTIME() - t_start;
 


### PR DESCRIPTION
… loop

build_upward_pass_work_lists emits a {child_box, parent_box} work item for each non-ifpwexp child with sources (so its charges get lifted directly into the parent's upward proxy). Multiple children of the same parent thus produce multiple work items sharing one `center_box`. charge2proxycharge accumulates into its output via `coeffs(...) += poly_x * dyz`, so when two threads process two same- center items concurrently the writes race on the same proxy_view_upward(center_box) memory.

Symptom: non-deterministic answers across runs at particular tree shapes (e.g. 3D Laplace free-space, ns=500, n_per_leaf=20 — the run sometimes passes at rel_err 4.67e-6, sometimes fails at rel_err 0.13). Single-thread runs are unaffected; the race is data-dependent so it can stay masked until a tree topology happens to trigger it.

Fix: group work items by center_box up front and parallelize over the groups. Each center is owned by exactly one thread during the pass, so concurrent writes to the same output buffer are impossible. The work per center is still small, so a dynamic schedule over groups keeps load balance.